### PR TITLE
SDK 4.1 SOAP changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ NOTE: This process has been greatly simplified with VMFest v0.2.3 and Pallet v0.
     (use 'pallet.compute)
     (use 'pallet.crate.automated-admin-user)
     (def service (compute-service-from-config-file :virtualbox))
-    (defnode test-node {:os-family :ubuntu :os-64-bit true} :bootstrap automated-amdin-user)
+    (defnode test-node {:os-family :ubuntu :os-64-bit true} :bootstrap automated-admin-user)
     (converge {test-node 1} :compute service)
        ;; Observe in the VirtualBox GUI that a new VM named test-node-0 has been created and started
        ;; Wait for the REPL to return and get the ip

--- a/src/vmfest/manager.clj
+++ b/src/vmfest/manager.clj
@@ -8,7 +8,7 @@
            [clojure.java.io :as io]
            vmfest.virtualbox.medium)
   (:use clojure.contrib.condition)
-  (:import org.virtualbox_4_0.SessionState java.io.File))
+  (:import org.virtualbox_4_1.SessionState java.io.File))
 
 (defn server [url & [identity credentials]]
   (vmfest.virtualbox.model.Server. url (or identity "") (or credentials "")))
@@ -44,6 +44,11 @@
 (defn set-bridged-network [m interface]
   {:pre [(model/IMachine? m)]}
   (machine/set-network-adapter m 0 :bridged interface)
+  (.saveSettings m))
+
+(defn set-nat-network [m]
+  {:pre [(model/IMachine? m)]}
+  (machine/set-network-adapter m 0 :nat "")
   (.saveSettings m))
 
 (defn configure-machine [vb-m param-map]

--- a/src/vmfest/virtualbox/conditions.clj
+++ b/src/vmfest/virtualbox/conditions.clj
@@ -1,12 +1,12 @@
 (ns vmfest.virtualbox.conditions
   (:use clojure.contrib.condition)
   (:require [clojure.tools.logging :as log])
-  (:import [org.virtualbox_4_0.jaxws
+  (:import [org.virtualbox_4_1.jaxws
             InvalidObjectFault
             InvalidObjectFaultMsg
             RuntimeFault
             RuntimeFaultMsg]
-           [org.virtualbox_4_0 VBoxException]))
+           [org.virtualbox_4_1 VBoxException]))
 
 (defn unsigned-int-to-long [ui]
   (bit-and (long ui) 0xffffffff))

--- a/src/vmfest/virtualbox/enums.clj
+++ b/src/vmfest/virtualbox/enums.clj
@@ -1,7 +1,7 @@
 (ns vmfest.virtualbox.enums
   (:require [clojure.tools.logging :as log])
   (:import
-   [org.virtualbox_4_0 IMachine MachineState ClipboardMode PointingHidType
+   [org.virtualbox_4_1 IMachine MachineState ClipboardMode PointingHidType
     FirmwareType KeyboardHidType SessionState SessionType StorageBus
     DeviceType NetworkAttachmentType CleanupMode]))
 
@@ -163,7 +163,7 @@
    [NetworkAttachmentType/Bridged :bridged ""]
    [NetworkAttachmentType/Internal :internal ""]
    [NetworkAttachmentType/HostOnly :host-only ""]
-   [NetworkAttachmentType/VDE :vde ""]])
+   [NetworkAttachmentType/Generic :generic ""]])
 (defn network-attachment-type-to-key [type]
   (find-key-by-value type network-attachment-type-to-key-table))
 (defn key-to-network-attachment-type [key]

--- a/src/vmfest/virtualbox/guest_os_type.clj
+++ b/src/vmfest/virtualbox/guest_os_type.clj
@@ -1,7 +1,7 @@
 (ns vmfest.virtualbox.guest-os-type
   (:require [vmfest.virtualbox.session :as session]
             [vmfest.virtualbox.model :as model])
-  (:import [org.virtualbox_4_0 IGuestOSType]))
+  (:import [org.virtualbox_4_1 IGuestOSType]))
 
 (defn map-from-IGuestOSType
   [o]

--- a/src/vmfest/virtualbox/image.clj
+++ b/src/vmfest/virtualbox/image.clj
@@ -4,7 +4,7 @@
         [clojure.pprint :only (pprint)])
   (:require [clojure.tools.logging :as log]
             [clojure.contrib.str-utils2 :as string])
-  (:import [org.virtualbox_4_0 DeviceType AccessMode MediumVariant
+  (:import [org.virtualbox_4_1 DeviceType AccessMode MediumVariant
             MediumType]
            [java.util.zip GZIPInputStream]
            [java.io File]))

--- a/src/vmfest/virtualbox/machine.clj
+++ b/src/vmfest/virtualbox/machine.clj
@@ -6,7 +6,7 @@
             [vmfest.virtualbox.model :as model]
             [vmfest.virtualbox.enums :as enums]
             [vmfest.virtualbox.session :as session])
-  (:import [org.virtualbox_4_0 IMachine IConsole VBoxException
+  (:import [org.virtualbox_4_1 IMachine IConsole VBoxException NetworkAttachmentType
             VirtualBoxManager IVirtualBox IMedium]
            [vmfest.virtualbox.model GuestOsType Machine]))
 
@@ -309,15 +309,15 @@ See IVirtualbox::openRemoteSession for more details"
   (try
     (if-let [adapter (.getNetworkAdapter m (long port))]
       (condp = type
-          :bridged (do (.attachToBridgedInterface adapter)
+          :bridged (do (.setAttachmentType adapter NetworkAttachmentType/Bridged)
                        ;; todo: get this from IHost.getNetworkInterfaces
-                       (.setHostInterface adapter interface))
-          :nat (.attachToNAT adapter)
-          :internal (.attachToInternalNetwork adapter)
-          :host-only (.attachToHostOnlyInterface adapter)
-          :vde (.attachToVDE adapter))
+                       (.setBridgedInterface adapter interface))
+          :nat (.setAttachmentType adapter NetworkAttachmentType/NAT)
+          :internal (.setAttachmentType adapter NetworkAttachmentType/Internal)
+          :host-only (.setAttachmentType adapter NetworkAttachmentType/HostOnly)
+          :generic (.setAttachmentType adapter NetworkAttachmentType/Generic)
       ;;todo -- raise a condition
-      )))
+      ))))
 
 (defn stop
   [^IConsole c]

--- a/src/vmfest/virtualbox/medium.clj
+++ b/src/vmfest/virtualbox/medium.clj
@@ -3,7 +3,7 @@
             [vmfest.virtualbox.virtualbox :as virtualbox]
             [vmfest.virtualbox.conditions :as conditions]
             [vmfest.virtualbox.session :as session])
-  (:import [org.virtualbox_4_0 IMedium]))
+  (:import [org.virtualbox_4_1 IMedium]))
 
 (defn map-from-IMedium
   [^IMedium m server]

--- a/src/vmfest/virtualbox/model.clj
+++ b/src/vmfest/virtualbox/model.clj
@@ -1,5 +1,5 @@
 (ns vmfest.virtualbox.model
-  (:import [org.virtualbox_4_0 IVirtualBox IMachine
+  (:import [org.virtualbox_4_1 IVirtualBox IMachine
             ISession VirtualBoxManager IMedium IConsole]))
 
 (defrecord Server [url username password])

--- a/src/vmfest/virtualbox/session.clj
+++ b/src/vmfest/virtualbox/session.clj
@@ -5,7 +5,7 @@ destruction of sessions with the VBox servers"
             [vmfest.virtualbox.conditions :as conditions]
             [vmfest.virtualbox.model :as model]
             [vmfest.virtualbox.enums :as enums])
-  (:import [org.virtualbox_4_0
+  (:import [org.virtualbox_4_1
             VirtualBoxManager
             IVirtualBox
             VBoxException
@@ -125,8 +125,8 @@ with a virtualbox.
                           e# {:message "unable to close session"}))))))))
 
 (def lock-type-constant
-  {:write org.virtualbox_4_0.LockType/Write
-   :shared org.virtualbox_4_0.LockType/Shared})
+  {:write org.virtualbox_4_1.LockType/Write
+   :shared org.virtualbox_4_1.LockType/Shared})
 
 (defmacro with-session
   [machine type [session vb-m] & body]

--- a/src/vmfest/virtualbox/virtualbox.clj
+++ b/src/vmfest/virtualbox/virtualbox.clj
@@ -4,7 +4,7 @@
             [vmfest.virtualbox.conditions :as conditions]
             [vmfest.virtualbox.enums :as enums]
             vmfest.virtualbox.guest-os-type)
-  (:import [org.virtualbox_4_0
+  (:import [org.virtualbox_4_1
             VirtualBoxManager
             IVirtualBox
             VBoxException]


### PR DESCRIPTION
#7 - point at VBox SDK 4.1 SOAP bindings. modifications to deal with API changes.

TODO: please update project.clj to point at vboxjws "4.1.2" once that's uploaded to clojars.
