### PR TITLE
configure-network can now add port-forwarding rules to adapters.

### DIFF
--- a/src/vmfest/virtualbox/enums.clj
+++ b/src/vmfest/virtualbox/enums.clj
@@ -4,7 +4,8 @@
    [org.virtualbox_4_2 IMachine MachineState ClipboardMode PointingHIDType
     FirmwareType KeyboardHIDType SessionState SessionType StorageBus
     DeviceType NetworkAttachmentType CleanupMode StorageControllerType
-    MediumType HostNetworkInterfaceType AccessMode MediumVariant]))
+    MediumType HostNetworkInterfaceType AccessMode MediumVariant
+    NATProtocol]))
 
 
 (defmacro find-key-by-value [value table]
@@ -185,6 +186,14 @@
   (find-key-by-value type network-attachment-type-to-key-table))
 (defn key-to-network-attachment-type [key]
   (find-value-by-key key network-attachment-type-to-key-table))
+
+(def nat-protocol-type-to-key-table
+  [[NATProtocol/UDP :udp ""]
+   [NATProtocol/TCP :tcp ""]])
+(defn nat-protocol-type-to-key [type]
+  (find-key-by-value type nat-protocol-type-to-key-table))
+(defn nat-protocol-type [key]
+  (find-value-by-key key nat-protocol-type-to-key-table))
 
 ;;; MediumType
 (def medium-type-type-to-key-table

--- a/test/vmfest/virtualbox/machine_config_test.clj
+++ b/test/vmfest/virtualbox/machine_config_test.clj
@@ -196,11 +196,21 @@
 
 (deftest ^{:integration true}
   nat-config-tests
-  (testing "You can add a NAT adapter"
+  (testing "You can add a NAT Rules for an adapter"
     (with-config-machine
       (let [config
-            [{:attachment-type :nat}]]))))
-
+            [{:attachment-type :nat
+              :nat-rules [{:name "http", :protocol :tcp,
+                           :host-ip "", :host-port 8080,
+                           :guest-ip "", :guest-port 80}]}]]
+        (configure-network m config)
+        (let [redirects (-> m (.getNetworkAdapter (long 0)) .getNATEngine .getRedirects)]
+          (is (= (count redirects) 1))
+          (is (= (first redirects)
+                 (format "%s,%s,%s,%s,%s,%s"
+                         "http" (.ordinal (enums/nat-protocol-type :tcp))
+                         "" (int 8080) "" (int 80)))))))))
+ 
 (def machine-config
   {:cpu-count 2
    :memory-size 555


### PR DESCRIPTION
Example: to configure an adapter that port forwards the host's port 8080 to the
guest's port 80:

``` clojure
(configure-network machine {:attachment-type :nat
                            :nat-rules [{:name "http", :protocol :tcp,
                                         :host-ip "", :host-port 8080,
                                         :guest-ip "", :guest-port 80}]})
```
