### PR TITLE
Make it possible to install vagrant base boxes as vmfest images

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
                  [slingshot "0.10.3"]
                  [org.clojure/tools.logging "0.2.3"]
                  [clj-http "0.5.8"]
-                 [fs "1.0.0"]]
+                 [fs "1.0.0"]
+                 [org.apache.commons/commons-compress "1.4.1"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [slingshot "0.10.3"]
                  [org.clojure/tools.logging "0.2.3"]
-                 [clj-http "0.5.8"]
                  [fs "1.0.0"]
                  [org.apache.commons/commons-compress "1.4.1"]]
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vmfest "0.3.0-alpha.1"
+(defproject vmfest "0.3.0-SNAPSHOT"
   :description "Manage local VMs from the REPL"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.2.1"]

--- a/src/vmfest/manager.clj
+++ b/src/vmfest/manager.clj
@@ -130,6 +130,19 @@ machines are stored in ~/.vmfest/nodes ."
 
 
 ;;; host functions
+(defn get-network-interfaces
+  "Returns a map for each active host network interfaces."
+  ([machine filter-map]
+     (session/with-session machine :shared [_ server]
+       (machine/get-network-interfaces server filter-map)))
+  ([machine] (get-network-interfaces machine {:status :up})))
+
+(defn get-network-adapters
+  "Returns a map for each active host network interfaces."
+  ([machine filter-map]
+     (session/with-session machine :shared [_ server]
+       (machine/get-network-adapters server filter-map)))
+  ([machine] (get-network-adapters machine {})))
 
 (defn get-usable-network-interfaces-from-vbox
   "Finds what host network interfaces are usable for bridging

--- a/src/vmfest/manager.clj
+++ b/src/vmfest/manager.clj
@@ -26,7 +26,9 @@ machines are stored in ~/.vmfest/nodes ."
   (:import [org.virtualbox_4_2
             SessionState
             HostNetworkInterfaceType
-            HostNetworkInterfaceStatus]
+            HostNetworkInterfaceStatus
+            IHostNetworkInterface
+            IVirtualBox]
            java.io.File
            vmfest.virtualbox.model.Machine)
   (:import [java.net NetworkInterface InetAddress]))
@@ -138,23 +140,24 @@ machines are stored in ~/.vmfest/nodes ."
 
 Note: :os-name is how vbox identifies the host network interfaces."
   [server]
-  (session/with-vbox server [vbox mgr]
+  (session/with-vbox server [_ vbox]
     (let [os-interface-name
           ;; needed because of how OSX adds a name to the OS i/f name
           ;; e.g. "en1: Airport" vs. "en1"
-          (fn [name]
+          (fn [^String name]
             (let [index  (.indexOf name ":")]
               (if (> index 0)
                 (.substring name 0 index)
                 name)))
           all-interfaces
-          (map (fn [ni] {:name (.getName ni) ;; the full OSX name
-                        :os-name (os-interface-name (.getName ni))
-                        :ip-address (.getIPAddress ni)
-                        :status (.getStatus ni)
-                        :interface-type (.getInterfaceType ni)
-                        :medium-type (.getMediumType ni)})
-               (.getNetworkInterfaces (.getHost mgr)))
+          (map (fn [^IHostNetworkInterface ni]
+                 {:name (.getName ni) ;; the full OSX name
+                  :os-name (os-interface-name (.getName ni))
+                  :ip-address (.getIPAddress ni)
+                  :status (.getStatus ni)
+                  :interface-type (.getInterfaceType ni)
+                  :medium-type (.getMediumType ni)})
+               (.getNetworkInterfaces (.getHost ^IVirtualBox vbox)))
           usable? ;; determine if an I/F is usable
           (fn [if]
             (and
@@ -176,10 +179,10 @@ Returns a sequence of interfaces as maps containing:
                          (some true? (map :reachable? ips)))
         nis (enumeration-seq (NetworkInterface/getNetworkInterfaces))
         ni-infos
-        (map (fn [ni]
+        (map (fn [^NetworkInterface ni]
                (let [ip-addresses (enumeration-seq (.getInetAddresses ni))
                      ip-info (map
-                              (fn [ip]
+                              (fn [^java.net.InetAddress ip]
                                 {:ip-address ip
                                  :reachable? (.isReachable ip 1000)})
                               ip-addresses)]
@@ -217,7 +220,7 @@ VirtualBox"
 
 ;;; jclouds/pallet-style infrastructure
 
-;; These are the hardware models to be instantiated. 
+;; These are the hardware models to be instantiated.
 (def ^{:dynamic true} *machine-models*
   {:micro
    {:memory-size 512
@@ -232,7 +235,7 @@ VirtualBox"
 
 (def ^{:dynamic true} *images* nil)
 
-(defn fs-dir [path]
+(defn fs-dir [^String path]
   (seq (.listFiles (java.io.File. path))))
 
 (defn image-meta-file? [^java.io.File file]
@@ -501,6 +504,7 @@ VirtualBox"
   [^Machine m]
   {:pre [(model/Machine? m)]}
   (try+
+   ;; when using the web iface, a lock is sometimes still held
    (let [return-val
          (session/with-session m :shared [s _]
            (machine/power-down (.getConsole s)))]
@@ -521,7 +525,7 @@ VirtualBox"
       (let [media (machine/unregister vb-m :detach-all-return-hard-disks-only)]
         (.waitForCompletion
          (machine/delete vb-m (if delete-disks media nil))
-         (Integer. timeout))))))
+         (Integer. (int timeout)))))))
 
 (defn send-keyboard [machine entries]
   "Given a sequence with a mix of character strings and keywords it
@@ -543,15 +547,15 @@ VirtualBox"
 (defn hard-disks [server]
   {:pre [(model/Server? server)]}
   (session/with-vbox server [_ vbox]
-    (doall (map #(model/dry % server) (.getHardDisks vbox)))))
+    (doall (map #(model/dry % server) (.getHardDisks ^IVirtualBox vbox)))))
 
 (defn machines [server & groups]
   {:pre [(model/Server? server)]}
   (session/with-vbox server [_ vbox]
     (let [machines
           (if groups
-            (.getMachinesByGroups vbox groups)
-            (.getMachines vbox))]
+            (.getMachinesByGroups ^IVirtualBox vbox groups)
+            (.getMachines ^IVirtualBox vbox))]
       (doall (map #(model/dry % server) machines)))))
 
 (defn managed-machines [server]
@@ -579,7 +583,7 @@ VirtualBox"
                       os-type-map
                       [:id :description :family-description :64-bit?]))]
       (map (comp get-keys vmfest.virtualbox.guest-os-type/map-from-IGuestOSType)
-           (.getGuestOSTypes vbox)))))
+           (.getGuestOSTypes ^IVirtualBox vbox)))))
 
 ;;; model forwards
 

--- a/src/vmfest/utils.clj
+++ b/src/vmfest/utils.clj
@@ -1,0 +1,34 @@
+(ns vmfest.utils
+  (:require
+   [clojure.java.io :as io])
+  (:import
+   [org.apache.commons.compress.archivers ArchiveStreamFactory]))
+
+(defn delete-file
+  "Delete file f. Raise an exception if it fails unless silently is true."
+  [f & [silently]]
+  (or (.delete (io/file f))
+      silently
+      (throw (java.io.IOException. (str "Couldn't delete " f)))))
+
+(defn delete-file-recursively
+  "Delete file f. If it's a directory, recursively delete all its contents.
+   Raise an ExceptionInInitializerError/ if any deletion fails unless silently
+   is true."
+  [f & [silently]]
+  (let [f (io/file f)]
+    (if (.isDirectory f)
+      (doseq [child (.listFiles f)]
+        (delete-file-recursively child silently)))
+    (delete-file f silently)))
+
+(defn untar [file dest]
+  (let [input (.. (ArchiveStreamFactory.)
+                  (createArchiveInputStream (io/input-stream file)))]
+    (loop [entry (.getNextEntry input)]
+      (when entry
+        (let [target (io/file dest (.getName entry))]
+          (if (.isDirectory entry)
+            (.mkdirs target)
+            (io/copy input target)))
+        (recur (.getNextEntry input))))))

--- a/src/vmfest/virtualbox/enums.clj
+++ b/src/vmfest/virtualbox/enums.clj
@@ -5,8 +5,7 @@
     FirmwareType KeyboardHIDType SessionState SessionType StorageBus
     DeviceType NetworkAttachmentType CleanupMode StorageControllerType
     MediumType HostNetworkInterfaceType AccessMode MediumVariant
-    NATProtocol]))
-
+    HostNetworkInterfaceStatus HostNetworkInterfaceMediumType  NATProtocol]))
 
 (defmacro find-key-by-value [value table]
   `(let [[v# k# _#] (first (filter (fn [[v# _# _#]] (= ~value v#)) ~table))]
@@ -221,6 +220,25 @@
   (find-key-by-value type host-network-interface-type-to-key-table))
 (defn key-to-host-network-interface-type [key]
   (find-value-by-key key host-network-interface-type-to-key-table))
+
+(def host-network-interface-medium-type-to-key-table
+  [[HostNetworkInterfaceMediumType/Ethernet :ethernet ""]
+   [HostNetworkInterfaceMediumType/PPP :ppp ""]
+   [HostNetworkInterfaceMediumType/SLIP :slip ""]
+   [HostNetworkInterfaceMediumType/Unknown :unknown ""]])
+(defn host-network-interface-medium-type-to-key [medium-type]
+  (find-key-by-value medium-type host-network-interface-medium-type-to-key-table))
+(defn key-to-host-network-interface-medium-type [key]
+  (find-value-by-key key host-network-interface-medium-type-to-key-table))
+
+(def host-network-interface-status-to-key-table
+  [[HostNetworkInterfaceStatus/Up :up ""]
+   [HostNetworkInterfaceStatus/Down :down ""]
+   [HostNetworkInterfaceStatus/Unknown :unknown ""]])
+(defn host-network-interface-status-to-key [status]
+  (find-key-by-value status host-network-interface-status-to-key-table))
+(defn key-to-host-network-interface-status [key]
+  (find-value-by-key key host-network-interface-status-to-key-table))
 
 
 ;;; CleanupMode

--- a/src/vmfest/virtualbox/enums.clj
+++ b/src/vmfest/virtualbox/enums.clj
@@ -127,7 +127,7 @@
    [SessionType/Shared :shared ""]])
 (defn session-type-to-key [type]
   (find-key-by-value type session-type-to-key-table))
-(defn key-to-session-type [key]
+(defn ^SessionType key-to-session-type [key]
   (find-value-by-key key session-type-to-key-table))
 
 ;;;StorageBus
@@ -140,7 +140,7 @@
    [StorageBus/SAS :sas ""]])
 (defn storage-bus-to-key [bus]
   (find-key-by-value bus storage-bus-to-key-table))
-(defn key-to-storage-bus [key]
+(defn ^StorageBus key-to-storage-bus [key]
   (find-value-by-key key storage-bus-to-key-table))
 
 (def storage-controller-type-to-key-table
@@ -170,7 +170,7 @@
    [DeviceType/SharedFolder :shared-folder "Shared folder device."]])
 (defn device-type-to-key [type]
   (find-key-by-value type device-type-to-key-table))
-(defn key-to-device-type [key]
+(defn ^DeviceType key-to-device-type [key]
   (find-value-by-key key device-type-to-key-table))
 
 ;;; NetworkAttachmentType
@@ -202,7 +202,7 @@
     "A medium which is is indirectly attached, so that one base medium can be used for several VMs which have their own differencing medium to store their modifications. In some sense a variant of Immutable with unset AutoReset flag in each differencing medium."]])
 (defn medium-type-type-to-key [type]
   (find-key-by-value type medium-type-type-to-key-table))
-(defn key-to-medium-type-type [key]
+(defn ^MediumType key-to-medium-type-type [key]
   (find-value-by-key key medium-type-type-to-key-table))
 
 (def host-network-interface-type-to-key-table
@@ -238,7 +238,7 @@
    [AccessMode/ReadWrite :read-write "Read & Write"]])
 (defn access-mode-type-to-key [type]
   (find-key-by-value type access-mode-type-to-key-table))
-(defn key-to-access-mode [key]
+(defn ^AccessMode key-to-access-mode [key]
   (find-value-by-key key access-mode-type-to-key-table))
 
 ;;; MediumVariant
@@ -260,5 +260,5 @@
          " Only used when passing the medium variant as an input parameter.")]])
 (defn medium-variant-type-to-key [type]
   (find-key-by-value type medium-variant-type-to-key-table))
-(defn key-to-medium-variant [key]
+(defn ^MediumVariant key-to-medium-variant [key]
   (find-value-by-key key medium-variant-type-to-key-table))

--- a/src/vmfest/virtualbox/enums.clj
+++ b/src/vmfest/virtualbox/enums.clj
@@ -4,7 +4,8 @@
    [org.virtualbox_4_2 IMachine MachineState ClipboardMode PointingHIDType
     FirmwareType KeyboardHIDType SessionState SessionType StorageBus
     DeviceType NetworkAttachmentType CleanupMode StorageControllerType
-    MediumType HostNetworkInterfaceType AccessMode MediumVariant]))
+    MediumType HostNetworkInterfaceType AccessMode MediumVariant
+    NATProtocol]))
 
 
 (defmacro find-key-by-value [value table]
@@ -185,6 +186,14 @@
   (find-key-by-value type network-attachment-type-to-key-table))
 (defn key-to-network-attachment-type [key]
   (find-value-by-key key network-attachment-type-to-key-table))
+
+(def nat-protocol-type-to-key-table
+  [[NATProtocol/UDP :udp ""]
+   [NATProtocol/TCP :tcp ""]])
+(defn nat-protocol-type-to-key [type]
+  (find-key-by-value type nat-protocol-type-to-key-table))
+(defn nat-protocol-type [key]
+  (find-value-by-key key nat-protocol-type-to-key-table))
 
 ;;; MediumType
 (def medium-type-type-to-key-table

--- a/src/vmfest/virtualbox/guest_os_type.clj
+++ b/src/vmfest/virtualbox/guest_os_type.clj
@@ -4,7 +4,7 @@
   (:import [org.virtualbox_4_2 IGuestOSType]))
 
 (defn map-from-IGuestOSType
-  [o]
+  [^IGuestOSType o]
   {:family-id (.getFamilyId o)
    :family-description (.getFamilyDescription o)
    :id (.getId o)

--- a/src/vmfest/virtualbox/image.clj
+++ b/src/vmfest/virtualbox/image.clj
@@ -2,6 +2,7 @@
   (:use [clojure.java.io]
         [vmfest.virtualbox.session :only (with-vbox)]
         [clojure.pprint :only (pprint)]
+        [vmfest.utils :only [untar]]
         [vmfest.virtualbox.virtualbox :only (find-medium)]
         [vmfest.virtualbox.system-properties :only [supported-medium-formats
                                                     default-hard-disk-format]]
@@ -80,6 +81,7 @@
                                              image-url)
         image-name (file-name-without-extensions image-file-name)
         gzipped? (.endsWith image-file-name ".gz")
+        vagrant-box? (.endsWith image-file-name ".box")
         model-name (or model-name image-name)
         model-unique-name (str "vmfest-" model-name)
         meta-url (or meta-url
@@ -93,10 +95,15 @@
      :image-file-name image-file-name
      :gzipped? gzipped?
      :gzipped-image-file (str temp-dir File/separator image-file-name)
-     :image-file (str temp-dir File/separator image-name ".vdi")
+     :vagrant-box? vagrant-box?
+     :image-file (if vagrant-box?
+                   (str temp-dir File/separator "box-disk1.vmdk")
+                   (str temp-dir File/separator image-name ".vdi"))
      :model-name model-name
      :model-path model-path
-     :model-file (str model-path File/separator model-unique-name ".vdi")
+     :model-file (if vagrant-box?
+                   (str model-path File/separator model-unique-name ".vmdk")
+                   (str model-path File/separator model-unique-name ".vdi"))
      :model-meta (str model-path File/separator model-unique-name ".meta")
      :temp-dir temp-dir
      :meta meta
@@ -107,9 +114,10 @@
 (def ^:dynamic *dry-run* false)
 
 (defn threaded-download
-  [{:keys [model-name image-url gzipped? gzipped-image-file image-file]
+  [{:keys [model-name image-url gzipped? gzipped-image-file image-file
+           vagrant-box?]
     :as options}]
-  (let [dest (if gzipped? gzipped-image-file image-file)]
+  (let [dest (if (or gzipped? vagrant-box?) gzipped-image-file image-file)]
     (log/infof "%s: Downloading %s into %s" model-name image-url dest )
     (when-not *dry-run*
       (download image-url dest)))
@@ -126,15 +134,35 @@
     (log/infof "%s: File %s is already uncompressed" model-name image-file))
   options)
 
+(defn threaded-unbox
+  [{:keys [model-name vagrant-box? temp-dir gzipped-image-file] :as options}]
+  (if vagrant-box?
+    (do
+      (log/infof "%s: Unpacking %s into %s"
+                 model-name gzipped-image-file temp-dir)
+      (when-not *dry-run*
+        (untar gzipped-image-file temp-dir)))
+    (log/infof "%s: Fileis not a vagrant box" model-name))
+  options)
+
 (defn threaded-get-metadata
-  [{:keys [model-name image-file meta meta-url] :as options}]
+  [{:keys [model-name image-file meta meta-url vagrant-box?] :as options}]
   (if meta
     (do
       (log/infof "%s: Metadata provided explicitly" model-name)
       options)
-    (do
-      (log/infof "%s: Loading metadata from %s" model-name meta-url)
-      (assoc options :meta (load-string (slurp meta-url))))))
+    (if vagrant-box?
+      (do
+        (log/infof "%s: Creating metadata for vagrant box" model-name)
+        (update-in options [:meta]
+                   #(merge
+                     {:username "vagrant"
+                      :sudo-password "vagrant"
+                      :no-sudo false}
+                     %)))
+      (do
+        (log/infof "%s: Loading metadata from %s" model-name meta-url)
+        (assoc options :meta (load-string (slurp meta-url)))))))
 
 (defn threaded-register-model
   [{:keys [image-file model-file vbox model-name] :as options}]
@@ -188,14 +216,15 @@
       (log/errorf
        "The model %s already exists. Manually specifiy another file name with :model-name"
        (:model-file job))
-      (do
-        (-> job
-            threaded-download
-            threaded-gunzip
-            threaded-get-metadata
-            threaded-register-model
-            threaded-create-meta
-            threaded-cleanup-temp-files)))))
+      (-> job
+          threaded-download
+          threaded-gunzip
+          threaded-unbox
+          threaded-get-metadata
+          threaded-register-model
+          threaded-create-meta
+          threaded-cleanup-temp-files))))
+
 
 (comment
  (use 'vmfest.manager)

--- a/src/vmfest/virtualbox/image.clj
+++ b/src/vmfest/virtualbox/image.clj
@@ -147,19 +147,21 @@
 
 (defn threaded-get-metadata
   [{:keys [model-name image-file meta meta-url vagrant-box?] :as options}]
-  (if meta
+  (if vagrant-box?
     (do
-      (log/infof "%s: Metadata provided explicitly" model-name)
-      options)
-    (if vagrant-box?
+      (log/infof "%s: Creating metadata for vagrant box" model-name)
+      (update-in options [:meta]
+                 #(merge
+                   {:username "vagrant"
+                    :password "vagrant"
+                    :sudo-password "vagrant"
+                    :no-sudo false
+                    :network-type :nat}
+                   %)))
+    (if meta
       (do
-        (log/infof "%s: Creating metadata for vagrant box" model-name)
-        (update-in options [:meta]
-                   #(merge
-                     {:username "vagrant"
-                      :sudo-password "vagrant"
-                      :no-sudo false}
-                     %)))
+        (log/infof "%s: Metadata provided explicitly" model-name)
+        options)
       (do
         (log/infof "%s: Loading metadata from %s" model-name meta-url)
         (assoc options :meta (load-string (slurp meta-url)))))))

--- a/src/vmfest/virtualbox/image.clj
+++ b/src/vmfest/virtualbox/image.clj
@@ -156,19 +156,24 @@
   (delete-file image-file true)
   options)
 
+(defn mutable? [medium]
+   (let [type (enums/medium-type-type-to-key (.getType medium))]
+     (or (= type :immutable) (= type :multi-attach))))
+
 (defn valid-model? [vbox id-or-location]
   ;; is the image registered?
   (let [medium (find-medium vbox id-or-location)]
     (if-not medium
-      (throw (RuntimeException.
-              (str "This model's image is not registered in VirtualBox: "
-                   id-or-location))))
+      (throw+ {:type :model-not-registered
+               :message
+               (str "This model's image is not registered in VirtualBox: "
+                    id-or-location)}))
     ;; is the image immutable?
-    (let [type (enums/medium-type-type-to-key (.getType medium))]
-      (if-not (or (= type :immutable) (= type :multi-attach))
-        (throw (RuntimeException.
-                (str "This model's image is not immutable nor multi-attach: "
-                     id-or-location)))))))
+    (if-not (mutable? medium)
+      (throw+ {:type :model-not-immutable
+               :message
+               (str "This model's image is not immutable nor multi-attach: "
+                    id-or-location)}))))
 
 (defn setup-model
   "Download a disk image from `image-url` and register it with `vbox`. Returns a

--- a/src/vmfest/virtualbox/image.clj
+++ b/src/vmfest/virtualbox/image.clj
@@ -161,6 +161,12 @@
   (if vagrant-box?
     (do
       (log/infof "%s: Creating metadata for vagrant box" model-name)
+      (when-not (every? (or (:meta options) {})
+                        [:os-family :os-version :os-64-bit])
+        (throw+
+         {:supplied-options (:meta options)}
+         (str "To install vagrant boxes, you must specify os-family, os-version"
+              " and os-64-bit")))
       (update-in options [:meta]
                  #(merge
                    {:username "vagrant"

--- a/src/vmfest/virtualbox/machine.clj
+++ b/src/vmfest/virtualbox/machine.clj
@@ -6,73 +6,74 @@
             [vmfest.virtualbox.enums :as enums]
             [vmfest.virtualbox.session :as session])
   (:use [vmfest.virtualbox.scan-codes :only (scan-codes)])
-  (:import [org.virtualbox_4_2 IMachine IConsole VBoxException
-            VirtualBoxManager IVirtualBox IMedium NetworkAttachmentType]
+  (:import [org.virtualbox_4_2 IMachine IConsole VBoxException ISession
+            VirtualBoxManager IVirtualBox IMedium NetworkAttachmentType
+            IStorageController INetworkAdapter IProgress]
            [vmfest.virtualbox.model GuestOsType Machine]))
 
 
 (def getters
-  {:name #(.getName %)
-   :description #(.getDescription %)
-   :accessible? #(.getAccessible %)
-   :access-error #(.getAccessError %) ;; todo. get object
-;;;   :os-type #(let [type-id (.getOSTypeId %)
+  {:name #(.getName ^IMachine %)
+   :description #(.getDescription ^IMachine %)
+   :accessible? #(.getAccessible ^IMachine %)
+   :access-error #(.getAccessError ^IMachine %) ;; todo. get object
+;;;   :os-type #(let [type-id (.getOSTypeId ^IMachine %)
 ;;;                  object (GuestOsType. type-id server)]
 ;;;              (model/as-map object))
-   :hardware-version #(.getHardwareVersion %)
-   :hardware-uuid #(.getHardwareUUID %)
-   :cpu-count #(.getCPUCount %)
-   :cpu-hot-plug-enabled? #(.getCPUHotPlugEnabled %)
-   :memory-size #(.getMemorySize %)
-   :memory-ballon-size #(.getMemoryBalloonSize %)
-   :page-fusion-enabled? #(.getPageFusionEnabled %)
-   :vram-size #(.getVRAMSize %)
-   :accelerate-3d-enabled? #(.getAccelerate3DEnabled %)
-   :accelerate-2d-video-enabled? #(.getAccelerate2DVideoEnabled %)
-   :monitor-count #(.getMonitorCount %)
-   :bios-settings #(.getBIOSSettings %) ;todo: get object
+   :hardware-version #(.getHardwareVersion ^IMachine %)
+   :hardware-uuid #(.getHardwareUUID ^IMachine %)
+   :cpu-count #(.getCPUCount ^IMachine %)
+   :cpu-hot-plug-enabled? #(.getCPUHotPlugEnabled ^IMachine %)
+   :memory-size #(.getMemorySize ^IMachine %)
+   :memory-ballon-size #(.getMemoryBalloonSize ^IMachine %)
+   :page-fusion-enabled? #(.getPageFusionEnabled ^IMachine %)
+   :vram-size #(.getVRAMSize ^IMachine %)
+   :accelerate-3d-enabled? #(.getAccelerate3DEnabled ^IMachine %)
+   :accelerate-2d-video-enabled? #(.getAccelerate2DVideoEnabled ^IMachine %)
+   :monitor-count #(.getMonitorCount ^IMachine %)
+   :bios-settings #(.getBIOSSettings ^IMachine %) ;todo: get object
    :firmware-type #(enums/firmware-type-to-key
-                   (.getFirmwareType %)) ;todo: get object
+                   (.getFirmwareType ^IMachine %)) ;todo: get object
    :pointing-hid-type #(enums/pointing-hid-type-to-key
-                       (.getPointingHIDType %)) ;todo: get object
+                       (.getPointingHIDType ^IMachine %)) ;todo: get object
    :keyboard-hid-type #(enums/keyboard-hid-type-to-key
-                       (.getKeyboardHIDType %)) ;todo: get object
-   :hpet-enabled #(.getHPETEnabled %)
-   :snapshot-folder #(.getSnapshotFolder %)
-   :vrde-server #(.getVRDEServer %) ;todo: get object
-   :medium-attachments #(.getMediumAttachments %) ;todo: get
+                       (.getKeyboardHIDType ^IMachine %)) ;todo: get object
+   :hpet-enabled #(.getHPETEnabled ^IMachine %)
+   :snapshot-folder #(.getSnapshotFolder ^IMachine %)
+   :vrde-server #(.getVRDEServer ^IMachine %) ;todo: get object
+   :medium-attachments #(.getMediumAttachments ^IMachine %) ;todo: get
                                         ;objects
-   :usb-controller #(.getUSBController %) ;todo: get object
-   :audio-adapter #(.getAudioAdapter %) ; todo: get object
-   :storage-controllers #(.getStorageControllers %) ;todo: get
+   :usb-controller #(.getUSBController ^IMachine %) ;todo: get object
+   :audio-adapter #(.getAudioAdapter ^IMachine %) ; todo: get object
+   :storage-controllers #(.getStorageControllers ^IMachine %) ;todo: get
                                         ;objects
-   :settings-file-path #(.getSettingsFilePath %)
-   :settings-modified? #(try (.getSettingsModified %)
+   :settings-file-path #(.getSettingsFilePath ^IMachine %)
+   :settings-modified? #(try (.getSettingsModified ^IMachine %)
                             (catch Exception e (comment "Do nothing")))
    :session-state #(enums/session-state-to-key
-                   (.getSessionState %)) ;todo: get object
-   :session-type #(enums/session-type-to-key (.getSessionType %))
-   :session-pid #(.getSessionPID %)
-   :state #(enums/machine-state-to-key (.getState %)) ;todo: get object
-   :last-state-change #(.getLastStateChange %) ;todo: make-date?
-   :state-file-path #(.getStateFilePath %)
-   :logFolder #(.getLogFolder %)
-   :current-snapshot #(.getCurrentSnapshot %)
-   :snapshot-count #(.getSnapshotCount %)
-   :current-state-modified? #(.getCurrentStateModified %)
-   :shared-folders #(.getSharedFolders %) ;todo: get objects
+                   (.getSessionState ^IMachine %)) ;todo: get object
+   :session-type #(enums/session-type-to-key (.getSessionType ^IMachine %))
+   :session-pid #(.getSessionPID ^IMachine %)
+   :state #(enums/machine-state-to-key (.getState ^IMachine %)) ;todo: get object
+   :last-state-change #(.getLastStateChange ^IMachine %) ;todo: make-date?
+   :state-file-path #(.getStateFilePath ^IMachine %)
+   :logFolder #(.getLogFolder ^IMachine %)
+   :current-snapshot #(.getCurrentSnapshot ^IMachine %)
+   :snapshot-count #(.getSnapshotCount ^IMachine %)
+   :current-state-modified? #(.getCurrentStateModified ^IMachine %)
+   :shared-folders #(.getSharedFolders ^IMachine %) ;todo: get objects
    :clipboard-mode #(enums/clipboard-mode-to-key
-                    (.getClipboardMode %)) ;todo: get object
+                    (.getClipboardMode ^IMachine %)) ;todo: get object
    :guest-property-notification-patterns
-   #(.getGuestPropertyNotificationPatterns %)
-   :teleporter-enabled? #(.getTeleporterEnabled %)
-   :teleporter-port #(.getTeleporterPort %)
-   :teleporter-address #(.getTeleporterAddress %)
-   :teleporter-password #(.getTeleporterPassword %)
-   :rtc-use-utc? #(.getRTCUseUTC %)
-   :io-cache-enabled? #(.getIOCacheEnabled %)
-   :io-cache-size #(.getIoCacheSize %)
-   ;;   :io-bandwidth-max #(.getIoBandwidthMax %)
+   #(.getGuestPropertyNotificationPatterns ^IMachine %)
+   :teleporter-enabled? #(.getTeleporterEnabled ^IMachine %)
+   :teleporter-port #(.getTeleporterPort ^IMachine %)
+   :teleporter-address #(.getTeleporterAddress ^IMachine %)
+   :teleporter-password #(.getTeleporterPassword ^IMachine %)
+   :rtc-use-utc? #(.getRTCUseUTC ^IMachine %)
+   :io-cache-enabled? #(.getIOCacheEnabled ^IMachine %)
+   :io-cache-size #(.getIOCacheSize ^IMachine %)
+   ;;   :io-bandwidth-max #(.getIoBandwidthMax ^IMachine %)
    })
 
 (defn get-attribute [vb-m getter-key]
@@ -146,35 +147,37 @@
    })
 
 (def setters
-  {:name #(.setName %2 %1)
-   :description #(.setDescription %2 %1)
-   :os-type-id #(.setOSTypeId %2 %1) ;; name is correct?
-   :hardware-version #(.setHardwareVersion %2 %1)
-   :hardware-uuid #(.setHardwareUUID %2 %1)
-   :cpu-count #(.setCPUCount %2 (long %1))
-   :cpu-hot-plug-enabled? #(.setCPUHotPlugEnabled %2 %1)
-   :memory-size #(.setMemorySize %2 (long %1))
-   :memory-balloon-size #(.setMemoryBalloonSize %2 (long %1))
-   :page-fusion-enabled? #(.setPageFusionEnabled %2 %1)
-   :vram-size #(.setVRAMSize %2 (long %1))
-   :accelerate-3d-enabled? #(.setAccelerate3DEnabled %2 %1)
-   :accelerate-2d-enabled? #(.setAccelerate2DEnabled %2 %1)
-   :monitor-count #(.setMonitorCount %2 (long %1))
-   :firmware-type #(.setFirmwareType %2 %1)
-   :pointing-hid-type #(.setPointingHIDType %2 %1)
-   :keyboard-hid-type #(.setKeyboardHIDType %2 %1)
-   :hpet-enabled #(.setHpetEnabled %2 %1)
-   :snapshot-folder #(.setSnapshotFolder %2 %1)
-   :clipboard-mode #(.setClipboardMode %2 %1)
-   :teleporter-enabled? #(.setTeleporterEnabled %2 %1)
+  {:name #(.setName ^IMachine %2 %1)
+   :description #(.setDescription ^IMachine %2 %1)
+   :os-type-id #(.setOSTypeId ^IMachine %2 %1) ;; name is correct?
+   :hardware-version #(.setHardwareVersion ^IMachine %2 %1)
+   :hardware-uuid #(.setHardwareUUID ^IMachine %2 %1)
+   :cpu-count #(.setCPUCount ^IMachine %2 (long %1))
+   :cpu-hot-plug-enabled? #(.setCPUHotPlugEnabled ^IMachine %2 %1)
+   :memory-size #(.setMemorySize ^IMachine %2 (long %1))
+   :memory-balloon-size #(.setMemoryBalloonSize ^IMachine %2 (long %1))
+   :page-fusion-enabled? #(.setPageFusionEnabled ^IMachine %2 %1)
+   :vram-size #(.setVRAMSize ^IMachine %2 (long %1))
+   :accelerate-3d-enabled? #(.setAccelerate3DEnabled
+                             ^IMachine %2 (boolean %1))
+   :accelerate-2d-video-enabled? #(.setAccelerate2DVideoEnabled
+                                   ^IMachine %2 (boolean %1))
+   :monitor-count #(.setMonitorCount ^IMachine %2 (long %1))
+   :firmware-type #(.setFirmwareType ^IMachine %2 %1)
+   :pointing-hid-type #(.setPointingHIDType ^IMachine %2 %1)
+   :keyboard-hid-type #(.setKeyboardHIDType ^IMachine %2 %1)
+   :hpet-enabled #(.setHPETEnabled ^IMachine %2 %1)
+   :snapshot-folder #(.setSnapshotFolder ^IMachine %2 %1)
+   :clipboard-mode #(.setClipboardMode ^IMachine %2 %1)
+   :teleporter-enabled? #(.setTeleporterEnabled ^IMachine %2 %1)
    :guest-property-notification-patters
-   #(.setGuestPropertyNotificationPatterns %2 %1)
-   :teleporter-port #(.setTeleporterPort %2 %1)
-   :teleporter-address #(.setTeleporterAddress %2 %1)
-   :teleporter-password #(.setTeleporterAddress %2 %1)
-   :rtc-use-utc? #(.setRTCUseUTC %2 %1)
-   :io-cache-enabled? #(.setIOCacheEnabled %2 %1)
-   :io-cache-size #(.setIOCacheSize %2 (long %1))
+   #(.setGuestPropertyNotificationPatterns ^IMachine %2 %1)
+   :teleporter-port #(.setTeleporterPort ^IMachine %2 %1)
+   :teleporter-address #(.setTeleporterAddress ^IMachine %2 %1)
+   :teleporter-password #(.setTeleporterAddress ^IMachine %2 %1)
+   :rtc-use-utc? #(.setRTCUseUTC ^IMachine %2 %1)
+   :io-cache-enabled? #(.setIOCacheEnabled ^IMachine %2 %1)
+   :io-cache-size #(.setIOCacheSize ^IMachine %2 (long %1))
    ;;   :io-bandwidth-max #(.setIoBandwidthMax %2 (long %1))
    })
 
@@ -226,12 +229,12 @@ Optional parameters are:
    :session-type 'gui', 'headless' or 'sdl'. Default is 'gui'
    :env environment as String to be passed to the machine at startup.
 See IVirtualbox::openRemoteSession for more details"
-  [mgr vbox machine-id & opt-kv]
+  [^VirtualBoxManager mgr ^IVirtualBox vbox machine-id & opt-kv]
   {:pre [(model/VirtualBoxManager? mgr)
          (model/IVirtualBox? vbox)]}
   (let [opts (apply hash-map opt-kv)
         session (.getSessionObject mgr)
-        session-type  (or (:session-type opts) "gui")
+        ^String session-type  (or (:session-type opts) "gui")
         env (or (:env opts) "DISPLAY:0.0")]
     (try
       (conditions/with-vbox-exception-translation
@@ -260,7 +263,7 @@ See IVirtualbox::openRemoteSession for more details"
          {:message "An error occurred while starting machine"})))))
 
 
-(defn save-settings [machine]
+(defn save-settings [^IMachine machine]
   {:pre [(model/IMachine? machine)]}
   (try
     (conditions/with-vbox-exception-translation
@@ -276,7 +279,7 @@ See IVirtualbox::openRemoteSession for more details"
 
 
 ;; TODO: This is redundant with machine-config/add-storage-controller
-(defn add-storage-controller  [m name bus-type]
+(defn add-storage-controller  [^IMachine m ^String name bus-type]
   {:pre [(model/IMachine? m)
          name
          (enums/key-to-storage-bus bus-type)]}
@@ -309,7 +312,7 @@ See IVirtualbox::openRemoteSession for more details"
                      type
                      medium))))
 
-(defn set-network-adapter [m port type interface]
+(defn set-network-adapter [^IMachine m port type ^INetworkAdapter interface]
   {:pre [(model/IMachine? m)
          port interface
          (enums/key-to-network-attachment-type type)]}
@@ -430,7 +433,7 @@ See IVirtualbox::openRemoteSession for more details"
 
 ;;;;;;;
 
-(defn unregister [vb-m & [cleanup-key]]
+(defn unregister [^IMachine vb-m & [cleanup-key]]
   {:pre [(model/IMachine? vb-m)
          (if cleanup-key (enums/key-to-cleanup-mode cleanup-key) true)]}
   ;; todo, make sure the key is valid
@@ -446,7 +449,7 @@ See IVirtualbox::openRemoteSession for more details"
        cleanup-mode)
       (.unregister vb-m cleanup-mode))))
 
-(defn delete [vb-m media]
+(defn ^IProgress delete [^IMachine vb-m ^IMedium media]
   {:pre [(model/IMachine? vb-m)]}
   (conditions/with-vbox-exception-translation
     {:VBOX_E_INVALID_VM_STATE
@@ -461,12 +464,13 @@ See IVirtualbox::openRemoteSession for more details"
   {:pre [(model/IMachine? vb-m)]}
   (enums/machine-state-to-key (.getState vb-m)))
 
-(defn get-storage-controller-by-name [m name]
+(defn ^IStorageController get-storage-controller-by-name
+  [^IMachine m ^String name]
   {:pre [(model/IMachine? m)]}
   (.getStorageControllerByName m name))
 
 ;;; scan codes
-(defn send-keyboard-entries [vb-m entries]
+(defn send-keyboard-entries [^ISession vb-m entries]
   "Given a sequence with a mix of:
      - strings corresponding to text
      - keywords corresponding to non-char key presses
@@ -490,5 +494,5 @@ See IVirtualbox::openRemoteSession for more details"
     (log/debugf "Sending to %s the scan-codes %s" (.getName (.getMachine vb-m)) scan-code-seq)
     (doseq [sc scan-code-seq]
       (if (number? sc)
-        (.putScancode keyboard (Integer. sc))
+        (.putScancode keyboard (Integer. (int sc)))
         (Thread/sleep (first sc))))))

--- a/src/vmfest/virtualbox/machine_config.clj
+++ b/src/vmfest/virtualbox/machine_config.clj
@@ -9,9 +9,11 @@
             [vmfest.virtualbox.virtualbox :as vbox]
             [vmfest.virtualbox.conditions :as conditions])
   (:import [org.virtualbox_4_2 AccessMode VBoxException NetworkAttachmentType
-            HostNetworkInterfaceType]))
+            HostNetworkInterfaceType INetworkAdapter IMedium IMachine
+            IHostNetworkInterface]))
 
-(defn get-medium [m {:keys [location device-type create] :as device}]
+(defn ^IMedium get-medium
+  [^IMachine m {:keys [location device-type create] :as device}]
   (let [vbox (.getParent m)]
     (when location
       (vbox/find-medium vbox location device-type))))
@@ -25,7 +27,8 @@
 (defn check-controller-type [bus controller-type]
   ((bus controller-type-checkers) controller-type))
 
-(defn add-storage-controller [m name storage-bus-key & [controller-type-key]]
+(defn add-storage-controller
+  [^IMachine m ^String name storage-bus-key & [controller-type-key]]
   (when (and controller-type-key
              (not (check-controller-type storage-bus-key controller-type-key)))
     (throw+ {:type :machine-builder
@@ -43,7 +46,7 @@
       (when controller-type
         (.setControllerType sc controller-type)))))
 
-(defn attach-device [m controller-name device port slot]
+(defn attach-device [^IMachine m ^String controller-name device port slot]
   {:pre (model/IMachine? m)}
   (log/debugf
    "attach-device: Attaching %s in controller %s slot %s port %s for machine %s"
@@ -66,15 +69,15 @@
        "A medium is already attached to this or another virtual machine."}
       (.attachDevice m
                      controller-name
-                     (Integer. port)
-                     (Integer. slot)
+                     (Integer. (int port))
+                     (Integer. (int slot))
                      device-type
                      medium))))
 
 (defmulti attach-devices
   (fn [m bus-type controller-name devices] bus-type))
 
-(defmethod attach-devices :ide [m bus-type controller-name devices]
+(defmethod attach-devices :ide [^IMachine m bus-type controller-name devices]
   (log/debugf
    "attach-devices: Attaching devices to %s in controller %s: %s"
    (.getName m) controller-name devices)
@@ -84,7 +87,7 @@
             (attach-device m controller-name device port slot)))
         devices [0 1 0 1] [0 0 1 1])))
 
-(defn simple-attach-devices [m controller-name devices]
+(defn simple-attach-devices [^IMachine m controller-name devices]
   (log/debugf
    "attach-devices: Attaching devices to %s in controller %s: %s"
    (.getName m) controller-name devices)
@@ -102,7 +105,7 @@
 (defmethod attach-devices :scsi [m bus-type controller-name devices]
   (simple-attach-devices m controller-name devices) )
 
-(defn configure-controller [m config]
+(defn configure-controller [^IMachine m config]
   (log/debugf
    "configure-controller: Configuring controller for machine '%s': %s"
    (.getName m) config)
@@ -110,7 +113,7 @@
         controller (add-storage-controller m name bus type)]
     (attach-devices m bus name devices)))
 
-(defn configure-storage [m config]
+(defn configure-storage [^IMachine m config]
   (log/debugf "Configuring storage for machine %s: %s"
               (.getName m) config)
   (doseq [controller-config config]
@@ -120,7 +123,7 @@
 
 ;;; network
 
-(defn set-adapter-property [adapter property-key value]
+(defn set-adapter-property [^INetworkAdapter adapter property-key value]
   (when value
     (condp = property-key
         :adapter-type (.setAdapterType adapter value)
@@ -146,19 +149,19 @@
     (doseq [[k v] config]
       (set-adapter-property adapter k v))))
 
-(defn attach-to-bridged [adapter]
+(defn attach-to-bridged [^INetworkAdapter adapter]
   (.setAttachmentType adapter NetworkAttachmentType/Bridged))
 
-(defn attach-to-nat [adapter]
+(defn attach-to-nat [^INetworkAdapter adapter]
   (.setAttachmentType adapter NetworkAttachmentType/NAT))
 
-(defn attach-to-host-only [adapter machine]
+(defn attach-to-host-only [^INetworkAdapter adapter ^IMachine machine]
   (let [vbox (.getParent machine)
         host (.getHost vbox)
         host-only-ifs (.findHostNetworkInterfacesOfType
                        host
                        HostNetworkInterfaceType/HostOnly)
-        host-if-names (map #(.getName %) host-only-ifs)
+        host-if-names (map #(.getName ^IHostNetworkInterface %) host-only-ifs)
         if-name (.getHostOnlyInterface adapter)]
     (when-not (some (partial = if-name) host-if-names)
       (log/warnf
@@ -173,7 +176,7 @@
                          if-name)}))))
   (.setAttachmentType adapter NetworkAttachmentType/HostOnly))
 
-(defn attach-to-internal [adapter]
+(defn attach-to-internal [^INetworkAdapter adapter]
   (.setAttachmentType adapter NetworkAttachmentType/Internal))
 
 (defn attach-adapter [machine adapter attachment-type]
@@ -187,7 +190,7 @@
          "configure-adapter: unrecognized attachment type %s" attachment-type)))
 
 (defn configure-adapter
-  [m slot config]
+  [^IMachine m slot config]
   (let [attachment-type (:attachment-type config)]
     (log/debugf
      "configure-adapter: Configuring network adapter for machine '%s' slot %s with %s"
@@ -196,7 +199,7 @@
       (configure-adapter-object adapter config)
       (attach-adapter m adapter attachment-type))))
 
-(defn configure-network [m config]
+(defn configure-network [^IMachine m config]
   (log/debugf "Configuring network for machine %s with %s"
               (.getName m) config)
   (let [vbox (.getParent m)
@@ -211,7 +214,7 @@
   (doseq [[entry value] config]
     (condp = entry
         :network (configure-network m value)
-        :storage nil ;; ignored. 
+        :storage nil ;; ignored.
         :boot-mount-point nil ;; ignored.
         (if-let [setter (entry machine/setters)]
           (setter value m)

--- a/src/vmfest/virtualbox/model.clj
+++ b/src/vmfest/virtualbox/model.clj
@@ -10,7 +10,7 @@
 
 (defprotocol vbox-object
   (as-map [this])
-  (soak [this vbox]))
+  (soak [this ^IVirtualBox vbox]))
 
 (defprotocol vbox-remote-object
   (dry [this server]))

--- a/src/vmfest/virtualbox/session.clj
+++ b/src/vmfest/virtualbox/session.clj
@@ -11,6 +11,7 @@ destruction of sessions with the VBox servers"
             IVirtualBox
             VBoxException
             LockType
+            IMachine
             ISession]
            [vmfest.virtualbox.model
             Server
@@ -122,6 +123,9 @@ VirtualBoxManager object plus the credentials or by a Server object.
 ;; wraps a code block and creates a vbox with a session before the
 ;; code in the block is executed, and it will disconnect once the
 ;; block has been executed, thus cleaning up the session.
+(defn cleanup-and-diconnect [^VirtualBoxManager mgr]
+  :pre [mgr]
+  (.cleanup mgr)) ;; cleanup calls disconnect in 4.2
 
 (defmacro with-vbox [^Server server [mgr vbox] & body]
   "Wraps a code block with the creation and the destruction of a session
@@ -140,10 +144,10 @@ with a virtualbox.
                     (when-not xpcom?
                       (when instance
                         (.cleanup instance))
-                      (.disconnect ~mgr))
-                    (catch Exception e#
-                      (conditions/wrap-exception
-                       e# {:message "unable to close session"}))))))))
+                      (cleanup-and-diconnect ~mgr)
+                      (catch Exception e#
+                        (conditions/wrap-exception
+                         e# {:message "unable to close session"})))))))))
 
 (def lock-type-constant
   {:write LockType/Write

--- a/src/vmfest/virtualbox/system_properties.clj
+++ b/src/vmfest/virtualbox/system_properties.clj
@@ -1,12 +1,13 @@
 (ns vmfest.virtualbox.system-properties
-  (:import [org.virtualbox_4_2 ISystemProperties IMachine IVirtualBox]))
+  (:import [org.virtualbox_4_2
+            ISystemProperties IMachine IVirtualBox IMediumFormat]))
 
-(defmulti system-properties class)
+(defmulti ^ISystemProperties system-properties class)
 
-(defmethod system-properties IVirtualBox [vbox]
+(defmethod system-properties IVirtualBox [^IVirtualBox vbox]
   (.getSystemProperties vbox))
 
-(defmethod system-properties IMachine [m]
+(defmethod system-properties IMachine [^IMachine m]
   (system-properties (.getParent m)))
 
 
@@ -79,8 +80,8 @@
   [o]
   (let [supported-formats (medium-formats o)
         format-ids
-        (map #(.getId %) supported-formats)]
-    (doall (map #(keyword (.toLowerCase %)) format-ids))))
+        (map #(.getId ^IMediumFormat %) supported-formats)]
+    (doall (map #(keyword (.toLowerCase ^String %)) format-ids))))
 
 ;; TODO: add missing functions:
 ;; getDefaultIoCacheSettingForStorageController

--- a/src/vmfest/virtualbox/version.clj
+++ b/src/vmfest/virtualbox/version.clj
@@ -7,7 +7,11 @@
          (try (import 'org.virtualbox_4_1.jaxws.IVirtualBoxCreateHardDisk)
               :ws
               (catch Exception e
-                :error)))))
+                (try
+                  (import 'org.virtualbox_4_2.jaxws.IVirtualBoxCreateHardDisk)
+                  :ws
+                  (catch Exception e
+                    :error)))))))
 
 (defonce xpcom? (= (vbox-binding) :xpcom))
 

--- a/test/vmfest/virtualbox/machine_config_test.clj
+++ b/test/vmfest/virtualbox/machine_config_test.clj
@@ -196,11 +196,21 @@
 
 (deftest ^{:integration true}
   nat-config-tests
-  (testing "You can add a NAT adapter"
+  (testing "You can add a NAT Rules for an adapter"
     (with-config-machine
       (let [config
-            [{:attachment-type :nat}]]))))
-
+            [{:attachment-type :nat
+              :nat-rules [{:name "http", :protocol :tcp,
+                           :host-ip "", :host-port 8080,
+                           :guest-ip "", :guest-port 80}]}]]
+        (configure-network m config)
+        (let [redirects (-> m (.getNetworkAdapter (long 0)) .getNATEngine .getRedirects)]
+          (is (= (count redirects) 1))
+          (is (= (first redirects)
+                 (format "%s,%s,%s,%s,%s,%s"
+                         "http" (.ordinal (enums/nat-protocol-type :tcp))
+                         "" (int 8080) "" (int 80)))))))))
+ 
 (def machine-config
   {:cpu-count 2
    :memory-size 555


### PR DESCRIPTION
Allowing the use of vagrant base boxes allows vmfest to use vagrant's library of boxes.
