### PR TITLE
fixed model-path typo in vmfest.manager

### DIFF
--- a/src/vmfest/manager.clj
+++ b/src/vmfest/manager.clj
@@ -277,7 +277,7 @@ VirtualBox"
 
 (defn model-info
   [model-key & {:keys [model-path] :or {model-path (:model-path *location*)}}]
-  (model-key (update-models :model-pathmodel-path)))
+  (model-key (update-models :model-path)))
 
 (defn check-model
   [server model-key & {:keys [model-path]

--- a/src/vmfest/manager.clj
+++ b/src/vmfest/manager.clj
@@ -277,7 +277,7 @@ VirtualBox"
 
 (defn model-info
   [model-key & {:keys [model-path] :or {model-path (:model-path *location*)}}]
-  (model-key (update-models :model-path)))
+  (model-key (update-models :model-path model-path)))
 
 (defn check-model
   [server model-key & {:keys [model-path]


### PR DESCRIPTION
Kept getting an error when trying to use vmfest.manager/model-info, looks like there was a typo in there.  I kept getting the error no value specified for :model-pathmodel-path.  Truncated to :model-path as it appears in the arg vector.  I think that should do the trick.  Please excuse the typos in my commit.  

Thanks!
Dan J
